### PR TITLE
Add support for catching uncaught server exceptions with patchGlobal

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,28 @@ Raven also works very well with saving full error and exception stack traces. Si
 <pre>
 RavenLogger.log(new Meteor.Error(422, 'Failed to save object to database'));
 </pre>
+
+Catching uncaught exceptions on the server:
+<pre>
+RavenLogger.initialize({
+  client: 'your client DSN here',
+  server: 'your server DSN here'
+}, {
+  patchGlobal: true
+});
+</pre>
+
+You can also provide a callback to `patchGlobal`:
+<pre>
+RavenLogger.initialize({
+  client: 'your client DSN here',
+  server: 'your server DSN here'
+}, {
+  patchGlobal: function() {
+    console.log('Bye, bye, world');
+    process.exit(1);
+  }
+});
+</pre>
+
+If no callback is provided, the default behaviour is to `exit(1)`.

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,14 @@ var client;
 /**
  * Start the logger.
  *
+ * Options:
+ *  * trackUser: set to true: include in each message the Meteor user's ID and
+ *               username, if they're logged in
+ *  * patchGlobal: set to true or a function: enables catching global uncaught
+ *                 exceptions on the server. If this is set to a function, that
+ *                 function is invoked after the exception is sent to Sentry.
+ *                 The default callback calls `exit(1)`.
+ *
  * @param settings object      Client & Server DSN strings. { client: 'dsn here', server: 'dsn here' }
  * @param options object
  */
@@ -28,6 +36,17 @@ function initialize(settings, options) {
     debug('Server initialize ' + settings.server);
     var Raven = Npm.require('raven');
     client = new Raven.Client(settings.server);
+    if (options.patchGlobal) {
+      var callback;
+      if (typeof options.patchGlobal === "function") {
+        callback = options.patchGlobal;
+      } else {
+        callback = function() {
+          process.exit(1);
+        };
+      }
+      client.patchGlobal(callback);
+    }
     isRavenEnabled = true;
   }
 }


### PR DESCRIPTION
I wanted to use `meteor-raven` while still capturing uncaught exceptions, so I thought I'd forward this functionality on. Thoughts?
